### PR TITLE
引入moment，并添加package.json及.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+bower_components
+.git

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ var bodyParser = require('body-parser')
 var _ = require('underscore')
 var port = process.env.PORT || 80
 var app = express()
-
+app.locals.moment = require('moment')
 mongoose.connect('mongodb://localhost/imooc')
 
 app.set('views','./views/pages')

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "imooc",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "pm2": "^1.1.2"
+  },
+  "devDependencies": {
+    "body-parser": "^1.15.0",
+    "cheerio": "^0.20.0",
+    "eventproxy": "^0.3.4",
+    "express": "^4.13.4",
+    "jade": "^1.11.0",
+    "moment": "^2.13.0",
+    "mongodb": "^2.1.18",
+    "mongoose": "^4.4.14",
+    "path": "^0.12.7",
+    "superagent": "^1.8.3",
+    "underscore": "^1.8.3"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Ella",
+  "license": "MIT"
+}


### PR DESCRIPTION
1. 项目直接运行node app.js时，访问localhost:80/admin/list页面时，其时间显示有问题。
   原因在于未在app.js中引入moment，此pr中将moment引入
2. 项目clone到本地时，缺乏本地环境
   添加package.json及.gitignore，便于使用的人复制项目后，直接通过npm install安装所需基本环境。
